### PR TITLE
Add basic boxing odds CLI and bet tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Boxing Betting Utilities
+
+This project contains scripts for working with boxing betting data.  A new
+command-line application `boxing_app.py` provides quick access to:
+
+- **Upcoming fights** based on the collected odds data.
+- **Best available odds** for each fighter across bookmakers.
+- **Value bets** where the best odds significantly exceed the average market price.
+
+Run the app with:
+
+```bash
+python boxingproject/boxing_app.py
+```
+
+A simple `BetTracker` utility is also included for recording and reviewing
+betting history.  Example usage:
+
+```python
+from boxingproject.bet_tracker import Bet, BetTracker
+from datetime import datetime
+
+tracker = BetTracker()
+tracker.add_bet(Bet(datetime.now(), "Fighter Name", 2.5, 10, "bookmaker"))
+print(tracker.summary())
+```

--- a/boxingproject/bet_tracker.py
+++ b/boxingproject/bet_tracker.py
@@ -1,0 +1,51 @@
+"""Simple bet tracking utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import pandas as pd
+
+
+@dataclass
+class Bet:
+    date: datetime
+    fighter: str
+    odds: float
+    stake: float
+    bookmaker: str
+    result: str | None = None  # 'win' or 'loss'
+    payout: float | None = None
+
+
+class BetTracker:
+    """Track bets in a CSV file."""
+
+    def __init__(self, filepath: str | Path | None = None) -> None:
+        self.filepath = Path(filepath) if filepath else Path(__file__).with_name("bets.csv")
+        if self.filepath.exists():
+            self.bets = pd.read_csv(self.filepath)
+        else:
+            self.bets = pd.DataFrame(columns=[
+                "date", "fighter", "odds", "stake", "bookmaker", "result", "payout"
+            ])
+
+    def add_bet(self, bet: Bet) -> None:
+        row = {
+            "date": bet.date.isoformat(),
+            "fighter": bet.fighter,
+            "odds": bet.odds,
+            "stake": bet.stake,
+            "bookmaker": bet.bookmaker,
+            "result": bet.result,
+            "payout": bet.payout,
+        }
+        self.bets = pd.concat([self.bets, pd.DataFrame([row])], ignore_index=True)
+        self.bets.to_csv(self.filepath, index=False)
+
+    def summary(self) -> pd.DataFrame:
+        """Return a summary of profits and losses."""
+        df = self.bets.copy()
+        df["payout"].fillna(0, inplace=True)
+        df["profit"] = df["payout"] - df["stake"]
+        return df

--- a/boxingproject/boxing_app.py
+++ b/boxingproject/boxing_app.py
@@ -1,0 +1,98 @@
+"""Simple command-line boxing odds app.
+
+This module loads boxing odds data from a CSV file and provides
+utilities for:
+    * Listing upcoming fights
+    * Finding the best available odds for each fighter
+    * Highlighting potential value bets (odds notably above average)
+
+The data source is expected to be `boxing_odds.csv` located in the same
+folder as this script.  The CSV is produced by the existing data
+collection notebooks and scripts in this repository.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+
+ODDS_FILE = Path(__file__).with_name("boxing_odds.csv")
+
+
+def load_odds() -> pd.DataFrame:
+    """Load odds data from ``boxing_odds.csv``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing the raw odds data.
+    """
+    return pd.read_csv(ODDS_FILE)
+
+
+def upcoming_fights(df: pd.DataFrame) -> pd.DataFrame:
+    """Return upcoming fight times and identifiers.
+
+    Parameters
+    ----------
+    df:
+        Raw odds DataFrame.
+    """
+    fights = df[["event_id", "time"]].drop_duplicates()
+    fights["time"] = pd.to_datetime(fights["time"])
+    return fights.sort_values("time")
+
+
+def best_odds(df: pd.DataFrame) -> pd.DataFrame:
+    """Return the best odds for each fighter in every event.
+
+    Parameters
+    ----------
+    df:
+        Raw odds DataFrame.
+    """
+    ordered = df.sort_values("decimal_odds", ascending=False)
+    best = (
+        ordered.groupby(["event_id", "fighter", "time"], as_index=False)
+        .first()
+        [["event_id", "time", "fighter", "bookmaker", "decimal_odds"]]
+    )
+    best["time"] = pd.to_datetime(best["time"])
+    return best
+
+
+def value_bets(df: pd.DataFrame, threshold: float = 0.05) -> pd.DataFrame:
+    """Identify potential value bets.
+
+    A value bet is defined here as a fighter whose best available odds
+    are at least ``threshold`` (5% by default) above the average odds
+    offered across bookmakers.
+    """
+    grouped = df.groupby(["event_id", "fighter"])
+    avg = grouped["decimal_odds"].mean().rename("avg_odds")
+    best = grouped["decimal_odds"].max().rename("best_odds")
+    best_bm = df.loc[grouped["decimal_odds"].idxmax(), ["event_id", "fighter", "bookmaker"]]
+
+    merged = (
+        pd.concat([avg, best], axis=1)
+        .reset_index()
+        .merge(best_bm, on=["event_id", "fighter"])
+    )
+    merged["value_pct"] = (merged["best_odds"] - merged["avg_odds"]) / merged["avg_odds"]
+    return merged[merged["value_pct"] >= threshold].sort_values("value_pct", ascending=False)
+
+
+def main() -> None:
+    """Simple CLI entry-point."""
+    df = load_odds()
+    print("Upcoming fights:")
+    print(upcoming_fights(df), end="\n\n")
+
+    print("Best odds:")
+    print(best_odds(df), end="\n\n")
+
+    print("Value bets:")
+    print(value_bets(df))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- introduce `boxing_app.py` CLI for upcoming fights, best odds, and value bets
- add `BetTracker` utility with dataclass for simple bet logging
- document usage in new README

## Testing
- `python boxingproject/boxing_app.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689728050b4c833290b63fc95c30192c