### PR TITLE
Use stdlib for boxing betting CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,42 @@
 # Boxing Betting Utilities
 
-This project contains scripts for working with boxing betting data.  A new
-command-line application `boxing_app.py` provides quick access to:
+This project contains scripts for working with boxing betting data.  The
+`boxing_app.py` script is a small all-in-one command-line application that
+relies only on Python's standard library, making it easy to run in any
+environment (including Visual Studio) where Python 3.10+ is installed.
+The odds and bet files default to `boxing_odds.csv` and `bets.csv` in the
+project directory, but you can override them with `--odds-file` and
+`--bets-file` options.
 
-- **Upcoming fights** based on the collected odds data.
-- **Best available odds** for each fighter across bookmakers.
-- **Value bets** where the best odds significantly exceed the average market price.
+Features:
 
-Run the app with:
+* **Upcoming fights** based on the collected odds data
+* **Best available odds** for each fighter across bookmakers
+* **Value bets** where the best odds significantly exceed the market average
+* **Bet tracking** with simple profit/loss summaries
+
+The application exposes several sub-commands:
 
 ```bash
-python boxingproject/boxing_app.py
+# list upcoming fights
+python boxingproject/boxing_app.py fights
+
+# show best odds for each fighter
+python boxingproject/boxing_app.py best
+
+# highlight potential value bets (10% above average)
+python boxingproject/boxing_app.py value --threshold 0.1
+
+# record a bet and view your history
+python boxingproject/boxing_app.py add-bet "Fighter" 2.5 10 Bookmaker
+python boxingproject/boxing_app.py summary
+
+# specify custom file locations
+python boxingproject/boxing_app.py --odds-file data/odds.csv best
+python boxingproject/boxing_app.py --bets-file my_bets.csv summary
 ```
 
-A simple `BetTracker` utility is also included for recording and reviewing
-betting history.  Example usage:
-
-```python
-from boxingproject.bet_tracker import Bet, BetTracker
-from datetime import datetime
-
-tracker = BetTracker()
-tracker.add_bet(Bet(datetime.now(), "Fighter Name", 2.5, 10, "bookmaker"))
-print(tracker.summary())
-```
+The odds data must be stored in `boxingproject/boxing_odds.csv` by default.
+Bet records are saved to `boxingproject/bets.csv` unless a different file is
+specified. Times in the odds file should be ISO timestamps so they can be
+sorted and displayed cleanly.

--- a/boxingproject/boxing_app.py
+++ b/boxingproject/boxing_app.py
@@ -1,98 +1,177 @@
-"""Simple command-line boxing odds app.
-
-This module loads boxing odds data from a CSV file and provides
-utilities for:
-    * Listing upcoming fights
-    * Finding the best available odds for each fighter
-    * Highlighting potential value bets (odds notably above average)
-
-The data source is expected to be `boxing_odds.csv` located in the same
-folder as this script.  The CSV is produced by the existing data
-collection notebooks and scripts in this repository.
-"""
+"""Command-line boxing odds and bet tracking app using only stdlib."""
 from __future__ import annotations
 
+import argparse
+import csv
+from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
-import pandas as pd
+from statistics import mean
+from typing import List
 
-ODDS_FILE = Path(__file__).with_name("boxing_odds.csv")
+try:  # support running as a module or a script
+    from .bet_tracker import Bet, BetTracker
+except ImportError:  # pragma: no cover - fallback when executed as a script
+    from bet_tracker import Bet, BetTracker
 
-
-def load_odds() -> pd.DataFrame:
-    """Load odds data from ``boxing_odds.csv``.
-
-    Returns
-    -------
-    pandas.DataFrame
-        DataFrame containing the raw odds data.
-    """
-    return pd.read_csv(ODDS_FILE)
+DEFAULT_ODDS_FILE = Path(__file__).with_name("boxing_odds.csv")
+DEFAULT_BETS_FILE = Path(__file__).with_name("bets.csv")
 
 
-def upcoming_fights(df: pd.DataFrame) -> pd.DataFrame:
-    """Return upcoming fight times and identifiers.
-
-    Parameters
-    ----------
-    df:
-        Raw odds DataFrame.
-    """
-    fights = df[["event_id", "time"]].drop_duplicates()
-    fights["time"] = pd.to_datetime(fights["time"])
-    return fights.sort_values("time")
-
-
-def best_odds(df: pd.DataFrame) -> pd.DataFrame:
-    """Return the best odds for each fighter in every event.
-
-    Parameters
-    ----------
-    df:
-        Raw odds DataFrame.
-    """
-    ordered = df.sort_values("decimal_odds", ascending=False)
-    best = (
-        ordered.groupby(["event_id", "fighter", "time"], as_index=False)
-        .first()
-        [["event_id", "time", "fighter", "bookmaker", "decimal_odds"]]
-    )
-    best["time"] = pd.to_datetime(best["time"])
-    return best
+def load_odds(path: Path = DEFAULT_ODDS_FILE) -> List[dict]:
+    """Load odds rows from a CSV file, parsing times and odds."""
+    if not path.exists():
+        return []
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows: List[dict] = []
+        for row in reader:
+            row["decimal_odds"] = float(row["decimal_odds"])
+            # Parse time if provided; fallback to raw string
+            try:
+                row["time"] = datetime.fromisoformat(row["time"])
+            except Exception:
+                row["time"] = row["time"]
+            rows.append(row)
+        return rows
 
 
-def value_bets(df: pd.DataFrame, threshold: float = 0.05) -> pd.DataFrame:
-    """Identify potential value bets.
+def upcoming_fights(rows: List[dict]) -> List[dict]:
+    """Return upcoming fights sorted by earliest available time."""
+    fights: dict[str, datetime] = {}
+    for r in rows:
+        eid = r["event_id"]
+        time = r["time"]
+        if eid not in fights or time < fights[eid]:
+            fights[eid] = time
+    return [{"event_id": eid, "time": fights[eid]} for eid in sorted(fights, key=fights.get)]
 
-    A value bet is defined here as a fighter whose best available odds
-    are at least ``threshold`` (5% by default) above the average odds
-    offered across bookmakers.
-    """
-    grouped = df.groupby(["event_id", "fighter"])
-    avg = grouped["decimal_odds"].mean().rename("avg_odds")
-    best = grouped["decimal_odds"].max().rename("best_odds")
-    best_bm = df.loc[grouped["decimal_odds"].idxmax(), ["event_id", "fighter", "bookmaker"]]
 
-    merged = (
-        pd.concat([avg, best], axis=1)
-        .reset_index()
-        .merge(best_bm, on=["event_id", "fighter"])
-    )
-    merged["value_pct"] = (merged["best_odds"] - merged["avg_odds"]) / merged["avg_odds"]
-    return merged[merged["value_pct"] >= threshold].sort_values("value_pct", ascending=False)
+def best_odds(rows: List[dict]) -> List[dict]:
+    """Return best odds for each fighter in every event."""
+    best: dict[tuple[str, str], dict] = {}
+    for r in rows:
+        key = (r["event_id"], r["fighter"])
+        if key not in best or r["decimal_odds"] > best[key]["decimal_odds"]:
+            best[key] = {
+                "event_id": r["event_id"],
+                "time": r["time"],
+                "fighter": r["fighter"],
+                "bookmaker": r["bookmaker"],
+                "decimal_odds": r["decimal_odds"],
+            }
+    return list(best.values())
+
+
+def value_bets(rows: List[dict], threshold: float = 0.05) -> List[dict]:
+    """Identify value bets where best odds exceed average by ``threshold``."""
+    grouped: defaultdict[tuple[str, str], List[dict]] = defaultdict(list)
+    for r in rows:
+        grouped[(r["event_id"], r["fighter"])].append(r)
+
+    results: List[dict] = []
+    for (event_id, fighter), lst in grouped.items():
+        odds = [r["decimal_odds"] for r in lst]
+        avg_odds = mean(odds)
+        best_row = max(lst, key=lambda r: r["decimal_odds"])
+        value_pct = (best_row["decimal_odds"] - avg_odds) / avg_odds
+        if value_pct >= threshold:
+            results.append(
+                {
+                    "event_id": event_id,
+                    "time": best_row["time"],
+                    "fighter": fighter,
+                    "bookmaker": best_row["bookmaker"],
+                    "avg_odds": round(avg_odds, 2),
+                    "best_odds": best_row["decimal_odds"],
+                    "value_pct": round(value_pct, 2),
+                }
+            )
+    results.sort(key=lambda r: r["value_pct"], reverse=True)
+    return results
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Boxing betting utilities")
+    parser.add_argument("--odds-file", type=Path, default=DEFAULT_ODDS_FILE, help="Path to odds CSV")
+    parser.add_argument("--bets-file", type=Path, default=DEFAULT_BETS_FILE, help="Path to bets CSV")
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("fights", help="List upcoming fights")
+    sub.add_parser("best", help="Show best available odds")
+
+    value = sub.add_parser("value", help="List potential value bets")
+    value.add_argument("--threshold", type=float, default=0.05, help="Minimum value percentage")
+
+    add_bet = sub.add_parser("add-bet", help="Record a bet")
+    add_bet.add_argument("fighter")
+    add_bet.add_argument("odds", type=float)
+    add_bet.add_argument("stake", type=float)
+    add_bet.add_argument("bookmaker")
+    add_bet.add_argument("--result", choices=["win", "loss"])
+    add_bet.add_argument("--payout", type=float)
+
+    sub.add_parser("summary", help="Show bet history and profits")
+
+    return parser.parse_args()
+
+
+def _format(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.2f}"
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M")
+    return str(value)
+
+
+def _print_table(rows: List[dict], columns: List[str] | None = None) -> None:
+    if not rows:
+        print("No data available")
+        return
+    if columns is None:
+        columns = list(rows[0].keys())
+    widths = {c: max(len(c), *(len(_format(r.get(c, ""))) for r in rows)) for c in columns}
+    header = " ".join(c.ljust(widths[c]) for c in columns)
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        line = " ".join(_format(r.get(c, "")).ljust(widths[c]) for c in columns)
+        print(line)
 
 
 def main() -> None:
-    """Simple CLI entry-point."""
-    df = load_odds()
-    print("Upcoming fights:")
-    print(upcoming_fights(df), end="\n\n")
+    args = _parse_args()
 
-    print("Best odds:")
-    print(best_odds(df), end="\n\n")
+    if args.command in {"fights", "best", "value"}:
+        odds = load_odds(args.odds_file)
+        if args.command == "fights":
+            _print_table(upcoming_fights(odds), ["event_id", "time"])
+        elif args.command == "best":
+            _print_table(best_odds(odds), ["event_id", "time", "fighter", "bookmaker", "decimal_odds"])
+        elif args.command == "value":
+            _print_table(
+                value_bets(odds, threshold=args.threshold),
+                ["event_id", "time", "fighter", "bookmaker", "avg_odds", "best_odds", "value_pct"],
+            )
+    elif args.command == "add-bet":
+        tracker = BetTracker(args.bets_file)
+        bet = Bet(
+            datetime.now(),
+            args.fighter,
+            args.odds,
+            args.stake,
+            args.bookmaker,
+            args.result,
+            args.payout,
+        )
+        tracker.add_bet(bet)
+        print("Bet added")
+    elif args.command == "summary":
+        tracker = BetTracker(args.bets_file)
+        _print_table(tracker.summary())
 
-    print("Value bets:")
-    print(value_bets(df))
 
-
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()
+


### PR DESCRIPTION
## Summary
- Allow odds and bet CSV paths to be overridden via `--odds-file` and `--bets-file`
- Parse fight times as datetimes and format table output for numbers and timestamps
- Document configurable data files and new examples in README

## Testing
- `python boxingproject/boxing_app.py -h`
- `python boxingproject/boxing_app.py fights`
- `python boxingproject/boxing_app.py best | head -n 10`
- `python boxingproject/boxing_app.py value --threshold 0.1 | head -n 10`
- `python boxingproject/boxing_app.py add-bet "Test Fighter" 2.0 5 Book --result win --payout 10`
- `python boxingproject/boxing_app.py summary`
- `python boxingproject/boxing_app.py --bets-file tmp_bets.csv add-bet "Another Fighter" 3.0 4 Book2 --result loss --payout 0`
- `python boxingproject/boxing_app.py --bets-file tmp_bets.csv summary`


------
https://chatgpt.com/codex/tasks/task_e_6897b2ca5c4c83329976811aa81aba87